### PR TITLE
Mobile responsive design

### DIFF
--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -9,4 +9,17 @@
            p-5;
         /* p-5 transition hover:scale-[1.02] hover:shadow-xl; */
     }
+
+    /* Target the internal tab list container of ProTabs to allow horizontal scrolling on mobile */
+    .pro-tabs-scrollable > div:first-child {
+        @apply overflow-x-auto overflow-y-hidden whitespace-nowrap;
+        flex-wrap: nowrap !important;
+        scrollbar-width: none; /* Firefox */
+        -ms-overflow-style: none; /* Internet Explorer 10+ */
+    }
+
+    /* Hide scrollbar for Chrome, Safari and Opera */
+    .pro-tabs-scrollable > div:first-child::-webkit-scrollbar {
+        display: none;
+    }
 }

--- a/src/layout/AppSidebar.vue
+++ b/src/layout/AppSidebar.vue
@@ -6,7 +6,7 @@ import { useRequestOrderStore } from '@/stores/request-order/requestOrder.store'
 import { Motion } from '@motionone/vue';
 import { PhBook, PhChartBar, PhHouse, PhShoppingCart, PhTag, PhTicket, PhTruck, PhWrench } from '@phosphor-icons/vue';
 import { ProSidebar } from '@prosync_solutions/ui';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
 
 const route = useRoute();
@@ -23,7 +23,15 @@ const canViewBudget = computed(() => permissionStore.hasPermission(PermissionCod
 const canViewPO = computed(() => permissionStore.hasPermission(PermissionCodes.VIEW_PURCHASE_ORDER));
 const canViewDelivery = computed(() => permissionStore.hasPermission(PermissionCodes.VIEW_DELIVERY_ORDER));
 
+const isMobile = ref(typeof window !== 'undefined' ? window.innerWidth < 1024 : false);
+
+const checkMobile = () => {
+    isMobile.value = window.innerWidth < 1024;
+};
+
 onMounted(() => {
+    checkMobile();
+    window.addEventListener('resize', checkMobile);
     const user = localStorage.getItem('user');
     if (user) {
         try {
@@ -35,6 +43,10 @@ onMounted(() => {
             role.value = null;
         }
     }
+});
+
+onUnmounted(() => {
+    window.removeEventListener('resize', checkMobile);
 });
 
 // Build the NavItems matching ProSidebar schema
@@ -79,7 +91,7 @@ const navItems = computed(() =>
 <template>
     <Motion :initial="{ opacity: 0 }" :animate="{ opacity: 1 }" :transition="{ duration: 0.8 }" tag="div" class="relative z-[60]">
         <div class="h-screen bg-white">
-            <ProSidebar :key="route.path" :nav-items="navItems" :default-expanded="true" :persist-state="false">
+            <ProSidebar :key="`${route.path}-${isMobile}`" :nav-items="navItems" :default-expanded="!isMobile" :persist-state="false">
                 <template #logo="{ isExpanded }">
                     <router-link to="/" class="flex items-center justify-center p-1">
                         <h1 v-if="isExpanded" class="text-2xl font-extrabold leading-tight m-0 text-brand-primary truncate w-full text-center">DO SYSTEM</h1>

--- a/src/views/delivery/Deliveries.vue
+++ b/src/views/delivery/Deliveries.vue
@@ -15,7 +15,14 @@
 
             <!-- Tabs and Table -->
             <ProCard class="shadow-sm mt-6">
-                <ProTabs v-model="activeTab" :tabs="tabItems" @update:modelValue="handleTabChange">
+                
+                <!-- Mobile Tab Scroll Indicator -->
+                <div class="flex items-center text-xs text-gray-400 mb-2 lg:hidden w-full justify-end">
+                    <span class="italic mr-1">Swipe tabs</span>
+                    <PhArrowsLeftRight :size="14" class="animate-pulse" />
+                </div>
+
+                <ProTabs v-model="activeTab" :tabs="tabItems" @update:modelValue="handleTabChange" class="pro-tabs-scrollable">
                     <Motion :key="activeTab" :initial="{ opacity: 0, x: 30 }" :animate="{ opacity: 1, x: 0 }" :exit="{ opacity: 0, x: -30 }" :transition="{ duration: 0.8 }">
 
                         <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-4 gap-3">

--- a/src/views/delivery/Delivery.script.ts
+++ b/src/views/delivery/Delivery.script.ts
@@ -6,10 +6,11 @@ import { useToast } from 'primevue/usetoast';
 import { computed, defineComponent, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { ProCard, ProButton, ProTag, ProTable, ProTabs, ProSelect, ProDatePicker, ProInput } from '@prosync_solutions/ui';
+import { PhArrowsLeftRight } from '@phosphor-icons/vue';
 
 export default defineComponent({
     name: 'Deliveries',
-    components: { ProCard, ProButton, ProTag, ProTable, ProTabs, ProSelect, ProDatePicker, ProInput },
+    components: { ProCard, ProButton, ProTag, ProTable, ProTabs, ProSelect, ProDatePicker, ProInput, PhArrowsLeftRight },
     setup() {
         const deliveryStore = useDeliveryStore();
         const projectStore = useProjectStore();

--- a/src/views/delivery/components/deliveryWorkFlow/step1SelectPO/selectPO.vue
+++ b/src/views/delivery/components/deliveryWorkFlow/step1SelectPO/selectPO.vue
@@ -62,25 +62,24 @@
                     </div>
 
                     <!-- Pagination Controls -->
-                    <div class="flex justify-between items-center mt-4 gap-2" v-if="purchaseStore.pagination">
-                        <div class="flex items-center gap-2">
-                            <span>Rows per page:</span>
-                            <select :value="purchaseStore.pagination?.pageSize ?? 10" @change="handlePageSizeChange" class="border rounded px-2 py-1">
+                    <div class="flex flex-col md:flex-row flex-wrap justify-between items-center mt-4 gap-4 text-sm" v-if="purchaseStore.pagination">
+                        <div class="flex items-center justify-center gap-2 w-full md:w-auto">
+                            <span class="text-gray-600">Rows per page:</span>
+                            <select :value="purchaseStore.pagination?.pageSize ?? 10" @change="handlePageSizeChange" class="border rounded px-2 py-1 bg-white">
                                 <option v-for="size in [10, 25, 50, 100]" :key="size" :value="size">{{ size }}</option>
                             </select>
                         </div>
 
-                        <div class="flex items-center gap-1">
+                        <div class="flex items-center justify-center gap-1 w-full md:w-auto">
                             <ProButton variant="ghost" :disabled="(purchaseStore.pagination?.page ?? 1) <= 1" @click="setPage(1)"><i class="pi pi-angle-double-left shrink-0" /></ProButton>
                             <ProButton variant="ghost" :disabled="(purchaseStore.pagination?.page ?? 1) <= 1" @click="setPage((purchaseStore.pagination?.page ?? 1) - 1)"><i class="pi pi-angle-left shrink-0" /></ProButton>
-                            <span> Page {{ purchaseStore.pagination?.page ?? 1 }} / {{ purchaseStore.pagination?.totalPages ?? 1 }} </span>
+                            <span class="px-2 font-medium"> Page {{ purchaseStore.pagination?.page ?? 1 }} / {{ purchaseStore.pagination?.totalPages ?? 1 }} </span>
                             <ProButton variant="ghost" :disabled="(purchaseStore.pagination?.page ?? 1) >= (purchaseStore.pagination?.totalPages ?? 1)" @click="setPage((purchaseStore.pagination?.page ?? 1) + 1)"><i class="pi pi-angle-right shrink-0" /></ProButton>
                             <ProButton variant="ghost" :disabled="(purchaseStore.pagination?.page ?? 1) >= (purchaseStore.pagination?.totalPages ?? 1)" @click="setPage(purchaseStore.pagination?.totalPages ?? 1)"><i class="pi pi-angle-double-right shrink-0" /></ProButton>
                         </div>
 
-                        <div>
-                            Showing
-                            {{ displayStart }} – {{ displayEnd }} of {{ purchaseStore.pagination?.total ?? 0 }}
+                        <div class="text-gray-500 text-center w-full md:w-auto text-xs md:text-sm">
+                            Showing {{ displayStart }} – {{ displayEnd }} of {{ purchaseStore.pagination?.total ?? 0 }}
                         </div>
                     </div>
 

--- a/src/views/delivery/components/deliveryWorkFlow/step3DeliveryInfo/deliveryInfo.vue
+++ b/src/views/delivery/components/deliveryWorkFlow/step3DeliveryInfo/deliveryInfo.vue
@@ -13,7 +13,7 @@
                 <span>Delivery Information</span>
             </div>
             <form @submit.prevent="onFormSubmit" class="flex flex-col gap-4 mt-1 w-full">
-                    <div class="grid grid-cols-2 gap-4 p-3">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 p-3">
                         <div class="flex flex-col">
                             <label for="driverPlate">Driver Plate Number</label>
                             <ProInput name="driverPlate" v-model="initialValues.driverPlate" placeholder="Plate Number" fluid />
@@ -24,7 +24,7 @@
 
                         <div class="flex flex-col">
                             <label for="deliveryDate">Delivery Date</label>
-                            <Calendar name="deliveryDate" v-model="initialValues.deliveryDate" placeholder="Select Date" showIcon :showTime="false" dateFormat="yy-mm-dd" />
+                            <Calendar name="deliveryDate" v-model="initialValues.deliveryDate" placeholder="Select Date" showIcon :showTime="false" dateFormat="yy-mm-dd" class="w-full" />
                             <Message v-if="errors.deliveryDate" severity="error" size="small" variant="simple">
                                 {{ errors.deliveryDate }}
                             </Message>

--- a/src/views/delivery/components/deliveryWorkFlow/step4Review/review.script.ts
+++ b/src/views/delivery/components/deliveryWorkFlow/step4Review/review.script.ts
@@ -6,6 +6,7 @@ import { useToast } from 'primevue/usetoast';
 import { computed, defineComponent, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { ProCard, ProButton, ProTag, ProTable } from '@prosync_solutions/ui';
+import { PhArrowsLeftRight } from '@phosphor-icons/vue';
 
 export default defineComponent({
     name: 'Review',
@@ -14,7 +15,8 @@ export default defineComponent({
         ProCard,
         ProButton,
         ProTag,
-        ProTable
+        ProTable,
+        PhArrowsLeftRight
     },
     emits: ['update', 'next-step', 'prev-step'],
     props: {

--- a/src/views/delivery/components/deliveryWorkFlow/step4Review/review.vue
+++ b/src/views/delivery/components/deliveryWorkFlow/step4Review/review.vue
@@ -59,11 +59,20 @@
                 </ProCard>
             </div>
 
-            <div class="grid mt-4">
-                <div class="col-12">
+            <div class="grid mt-4 w-full" style="min-width: 0;">
+                <div class="col-12" style="min-width: 0;">
                     <ProCard class="shadow-sm">
-                        <h3 class="text-lg font-semibold mb-2">Items Summary</h3>
-                        <ProTable v-if="hasDeliveredItems" :data="deliveredItems" :columns="deliveryListColumn" emptyTitle="No Delivered Items" :loading="false" />
+                        <div class="flex flex-col sm:flex-row sm:items-center justify-between mb-2 lg:mb-4 gap-2">
+                            <h3 class="text-lg font-semibold">Items Summary</h3>
+                            <!-- Mobile Tab Scroll Indicator -->
+                            <div class="flex items-center text-xs text-gray-400 lg:hidden justify-end">
+                                <span class="italic mr-1">Swipe table</span>
+                                <PhArrowsLeftRight :size="14" class="animate-pulse" />
+                            </div>
+                        </div>
+                        <div class="w-full overflow-x-auto">
+                            <ProTable v-if="hasDeliveredItems" :data="deliveredItems" :columns="deliveryListColumn" emptyTitle="No Delivered Items" :loading="false" />
+                        </div>
                     </ProCard>
                 </div>
             </div>

--- a/src/views/delivery/components/pages/createDelivery/createDelivery.vue
+++ b/src/views/delivery/components/pages/createDelivery/createDelivery.vue
@@ -12,35 +12,35 @@
                 <!-- Steps relative layout -->
                 <div class="flex justify-between items-center w-full z-10 relative">
                     <!-- Step 1 -->
-                    <div class="flex flex-col items-center gap-2 w-24" :class="activeStep > 1 ? 'cursor-pointer hover:opacity-80' : 'cursor-default'" @click="activeStep > 1 && goStep(1)">
-                        <div :class="['w-10 h-10 rounded-full flex items-center justify-center border-2 transition-colors duration-300', activeStep >= 1 ? 'bg-brand-primary border-brand-primary text-white' : 'bg-surface-main-bg border-gray-300 text-gray-400']">
-                            <i class="pi pi-box"></i>
+                    <div class="flex flex-col items-center gap-1 sm:gap-2 w-[70px] sm:w-24" :class="activeStep > 1 ? 'cursor-pointer hover:opacity-80' : 'cursor-default'" @click="activeStep > 1 && goStep(1)">
+                        <div :class="['w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center border-2 transition-colors duration-300', activeStep >= 1 ? 'bg-brand-primary border-brand-primary text-white' : 'bg-surface-main-bg border-gray-300 text-gray-400']">
+                            <i class="pi pi-box text-sm sm:text-base"></i>
                         </div>
-                        <span :class="['text-sm font-medium', activeStep >= 1 ? 'text-brand-primary' : 'text-gray-500']">Select PO</span>
+                        <span :class="['text-[10px] sm:text-sm leading-tight text-center font-medium', activeStep >= 1 ? 'text-brand-primary' : 'text-gray-500']">Select PO</span>
                     </div>
 
                     <!-- Step 2 -->
-                    <div class="flex flex-col items-center gap-2 w-24" :class="activeStep > 2 ? 'cursor-pointer hover:opacity-80' : 'cursor-default'" @click="activeStep > 2 && goStep(2)">
-                        <div :class="['w-10 h-10 rounded-full flex items-center justify-center border-2 transition-colors duration-300', activeStep >= 2 ? 'bg-brand-primary border-brand-primary text-white' : 'bg-surface-main-bg border-gray-300 text-gray-400']">
-                            <i class="pi pi-check"></i>
+                    <div class="flex flex-col items-center gap-1 sm:gap-2 w-[70px] sm:w-24" :class="activeStep > 2 ? 'cursor-pointer hover:opacity-80' : 'cursor-default'" @click="activeStep > 2 && goStep(2)">
+                        <div :class="['w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center border-2 transition-colors duration-300', activeStep >= 2 ? 'bg-brand-primary border-brand-primary text-white' : 'bg-surface-main-bg border-gray-300 text-gray-400']">
+                            <i class="pi pi-check text-sm sm:text-base"></i>
                         </div>
-                        <span :class="['text-sm font-medium', activeStep >= 2 ? 'text-brand-primary' : 'text-gray-500']">Verify Items</span>
+                        <span :class="['text-[10px] sm:text-sm leading-tight text-center font-medium', activeStep >= 2 ? 'text-brand-primary' : 'text-gray-500']">Verify Items</span>
                     </div>
 
                     <!-- Step 3 -->
-                    <div class="flex flex-col items-center gap-2 w-24" :class="activeStep > 3 ? 'cursor-pointer hover:opacity-80' : 'cursor-default'" @click="activeStep > 3 && goStep(3)">
-                        <div :class="['w-10 h-10 rounded-full flex items-center justify-center border-2 transition-colors duration-300', activeStep >= 3 ? 'bg-brand-primary border-brand-primary text-white' : 'bg-surface-main-bg border-gray-300 text-gray-400']">
-                            <i class="pi pi-truck"></i>
+                    <div class="flex flex-col items-center gap-1 sm:gap-2 w-[70px] sm:w-24" :class="activeStep > 3 ? 'cursor-pointer hover:opacity-80' : 'cursor-default'" @click="activeStep > 3 && goStep(3)">
+                        <div :class="['w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center border-2 transition-colors duration-300', activeStep >= 3 ? 'bg-brand-primary border-brand-primary text-white' : 'bg-surface-main-bg border-gray-300 text-gray-400']">
+                            <i class="pi pi-truck text-sm sm:text-base"></i>
                         </div>
-                        <span :class="['text-sm font-medium', activeStep >= 3 ? 'text-brand-primary' : 'text-gray-500']">Delivery Info</span>
+                        <span :class="['text-[10px] sm:text-sm leading-tight text-center font-medium', activeStep >= 3 ? 'text-brand-primary' : 'text-gray-500']">Delivery Info</span>
                     </div>
 
                     <!-- Step 4 -->
-                    <div class="flex flex-col items-center gap-2 w-24 cursor-default">
-                        <div :class="['w-10 h-10 rounded-full flex items-center justify-center border-2 transition-colors duration-300', activeStep >= 4 ? 'bg-brand-primary border-brand-primary text-white' : 'bg-surface-main-bg border-gray-300 text-gray-400']">
-                            <i class="pi pi-file"></i>
+                    <div class="flex flex-col items-center gap-1 sm:gap-2 w-[70px] sm:w-24 cursor-default">
+                        <div :class="['w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center border-2 transition-colors duration-300', activeStep >= 4 ? 'bg-brand-primary border-brand-primary text-white' : 'bg-surface-main-bg border-gray-300 text-gray-400']">
+                            <i class="pi pi-file text-sm sm:text-base"></i>
                         </div>
-                        <span :class="['text-sm font-medium', activeStep >= 4 ? 'text-brand-primary' : 'text-gray-500']">Review</span>
+                        <span :class="['text-[10px] sm:text-sm leading-tight text-center font-medium', activeStep >= 4 ? 'text-brand-primary' : 'text-gray-500']">Review</span>
                     </div>
                 </div>
             </div>

--- a/src/views/delivery/components/smartScan/OcrResultTable.vue
+++ b/src/views/delivery/components/smartScan/OcrResultTable.vue
@@ -7,7 +7,11 @@
                 <tr class="bg-surface-50 border-b">
                     <th class="px-3 py-2 text-left font-semibold text-gray-600 w-10">#</th>
                     <th class="px-3 py-2 text-left font-semibold text-gray-600 min-w-[150px]">Item Code</th>
-                    <th class="px-3 py-2 text-left font-semibold text-gray-600 min-w-[500px]">Description <span class="text-xs text-gray-400">  (Hover to see the full description)</span></th>
+                    <th class="px-3 py-2 text-left font-semibold text-gray-600 min-w-[500px]">
+                        Description 
+                        <span class="text-xs text-gray-400 hidden lg:inline"> (Hover to view full)</span>
+                        <span class="text-xs text-gray-400 lg:hidden"> (Tap & swipe to read)</span>
+                    </th>
                     <th class="px-3 py-2 text-left font-semibold text-gray-600">Qty</th>
                     <th class="px-3 py-2 text-left font-semibold text-gray-600">UOM</th>
                     <th class="px-3 py-2 text-left font-semibold text-gray-600 min-w-[250px]">Remarks</th>

--- a/src/views/delivery/components/smartScan/SmartScanModal.vue
+++ b/src/views/delivery/components/smartScan/SmartScanModal.vue
@@ -65,10 +65,10 @@
         <div v-else-if="phase === 'result'" class="flex flex-col" style="min-height: 520px;">
 
             <!-- Side-by-side body -->
-            <div class="flex flex-1 overflow-hidden divide-x divide-surface-200" style="min-height: 480px;">
+            <div class="flex flex-col lg:flex-row flex-1 lg:overflow-hidden lg:divide-x divide-y lg:divide-y-0 divide-surface-200" style="min-height: 480px;">
 
                 <!-- LEFT: Extracted OCR data -->
-                <div class="flex flex-col flex-1 overflow-y-auto p-4" style="min-width: 0;">
+                <div class="flex flex-col flex-1 overflow-auto p-4" style="min-width: 0;">
                     <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">
                         <i class="pi pi-sparkles mr-1 text-orange-500" /> AI Extracted Data
                     </p>
@@ -105,19 +105,18 @@
                 </div>
 
                 <!-- RIGHT: Original file preview -->
-                <div class="flex flex-col" style="width: 48%; min-width: 320px;">
-                    <div class="px-4 pt-4 pb-2 border-b border-surface-100 flex items-center gap-2">
+                <div class="flex flex-col w-full lg:w-[48%]" style="min-width: 0;">
+                    <div class="px-4 pt-4 pb-2 lg:border-b border-surface-100 flex items-center gap-2">
                         <i class="pi pi-file text-orange-500" />
                         <p class="text-xs font-semibold text-gray-500 uppercase tracking-wide">Original Document</p>
                         <span class="ml-auto text-xs text-gray-400 truncate max-w-[160px]" :title="selectedFile?.name">{{ selectedFile?.name }}</span>
                     </div>
-                    <div class="flex-1 bg-surface-50 flex items-center justify-center overflow-hidden" style="min-height: 400px;">
+                    <div class="flex-1 bg-surface-50 w-full overflow-y-auto overflow-x-hidden md:flex md:items-center md:justify-center relative" style="min-height: 500px; -webkit-overflow-scrolling: touch;">
                         <!-- PDF preview -->
                         <iframe
                             v-if="filePreviewUrl && selectedFile?.type === 'application/pdf'"
                             :src="filePreviewUrl"
-                            class="w-full h-full border-0"
-                            style="min-height: 440px;"
+                            class="w-full h-full border-0 absolute top-0 left-0"
                         />
                         <!-- Image preview -->
                         <img

--- a/src/views/purchase-orders/PurchaseOrders.script.ts
+++ b/src/views/purchase-orders/PurchaseOrders.script.ts
@@ -7,7 +7,7 @@ import { usePurchaseOrderStore } from '@/stores/purchase-order/purchaseOrder.sto
 import type { PurchaseOrderWithStatus } from '@/types/purchase.type';
 import { Motion } from '@motionone/vue';
 import { ProButton, ProCard, ProStatisticCard, ProTable, ProTag, ProTabs, ProSelect, ProDatePicker, ProInput } from '@prosync_solutions/ui';
-import { PhBookOpen, PhCheckCircle, PhClock, PhWarning } from '@phosphor-icons/vue';
+import { PhBookOpen, PhCheckCircle, PhClock, PhWarning, PhArrowsLeftRight } from '@phosphor-icons/vue';
 
 // permission composable
 import { usePurchaseOrderPermission } from '@/permissions';
@@ -28,7 +28,8 @@ export default defineComponent({
         PhBookOpen,
         ProSelect,
         ProDatePicker,
-        ProInput
+        ProInput,
+        PhArrowsLeftRight
     },
     setup() {
         const isLoading = ref(true);

--- a/src/views/purchase-orders/PurchaseOrders.vue
+++ b/src/views/purchase-orders/PurchaseOrders.vue
@@ -56,7 +56,14 @@
 
             <!-- Tabs -->
             <ProCard class="shadow-sm mt-6">
-                <ProTabs v-model="activeTab" :tabs="tabItems" @update:modelValue="handleTabChange">
+                
+                <!-- Mobile Tab Scroll Indicator -->
+                <div class="flex items-center text-xs text-gray-400 mb-2 lg:hidden w-full justify-end">
+                    <span class="italic mr-1">Swipe tabs</span>
+                    <PhArrowsLeftRight :size="14" class="animate-pulse" />
+                </div>
+
+                <ProTabs v-model="activeTab" :tabs="tabItems" @update:modelValue="handleTabChange" class="pro-tabs-scrollable">
                     <Motion :key="activeTab" :initial="{ opacity: 0, x: 30 }" :animate="{ opacity: 1, x: 0 }" :exit="{ opacity: 0, x: -30 }" :transition="{ duration: 0.8 }">
 
                         <!-- Shared Toolbar for all tabs -->

--- a/src/views/request-orders/RequestOrders.script.ts
+++ b/src/views/request-orders/RequestOrders.script.ts
@@ -13,7 +13,7 @@ import { useRequestOrderPermission } from '@/permissions';
 import { useProjectStore } from '@/stores/project/project.store';
 import { USER_ROLE_TO_APPROVAL_ROLE } from '@/utils/approvalRole.util';
 import { formatCurrency } from '@/utils/format.utils';
-import { PhCheck, PhDotsThreeVertical, PhEye, PhPencilSimple, PhTrash, PhX } from '@phosphor-icons/vue';
+import { PhCheck, PhDotsThreeVertical, PhEye, PhPencilSimple, PhTrash, PhX, PhArrowsLeftRight } from '@phosphor-icons/vue';
 import { ProButton, ProCard, ProIconButton, ProInput, ProMenu, ProPageHeader, ProSelect, ProTable, ProTabs, ProTag, ProDatePicker } from '@prosync_solutions/ui';
 import { computed, defineComponent, onMounted, ref, watch } from 'vue';
 import type { Order } from '../../types/request-order.type';
@@ -46,6 +46,7 @@ export default defineComponent({
         RejectRo,
         ApproveRo,
         PhDotsThreeVertical,
+        PhArrowsLeftRight,
         ProDatePicker
     },
     setup() {

--- a/src/views/request-orders/RequestOrders.vue
+++ b/src/views/request-orders/RequestOrders.vue
@@ -25,7 +25,14 @@ import { Button } from "@prosync/ui-kit";
 
             <!-- Tabs and Table Wrap in Card -->
             <ProCard class="shadow-sm">
-                <ProTabs v-model="activeTab" :tabs="tabItems">
+                
+                <!-- Mobile Tab Scroll Indicator -->
+                <div class="flex items-center text-xs text-gray-400 mb-2 lg:hidden w-full justify-end">
+                    <span class="italic mr-1">Swipe tabs</span>
+                    <PhArrowsLeftRight :size="14" class="animate-pulse" />
+                </div>
+
+                <ProTabs v-model="activeTab" :tabs="tabItems" class="pro-tabs-scrollable">
                         <Motion :key="activeTab" :initial="{ opacity: 0, x: 30 }" :animate="{ opacity: 1, x: 0 }" :exit="{ opacity: 0, x: -30 }" :transition="{ duration: 0.8 }">
                             
                             <div class="flex justify-end mb-4">


### PR DESCRIPTION
- Resize and collapsed the sidebar if resolution decrease into mobile width
- Make the tab scrollable to the left and right
- for page that got many tab, this resolved the issue
- use Phosphor icon
- Implement responsive tab at ProTab in PO page

Make the delivery module mobile responsive at:
- tab
- now scan result table will be at top and the pdf file at bottom
- create delivery page which make the rows per page and total count in vertically stacked for mobile view
- delivery info which make the delivery date stacked with the no plate
- review page which make the protable scrollable left and right
