### PR TITLE
DO new enhancement

### DIFF
--- a/src/services/deliveryOrder.service.ts
+++ b/src/services/deliveryOrder.service.ts
@@ -80,11 +80,26 @@ const previewAttachment = (file: AttachmentItem) => {
     window.open(url, '_blank');
 };
 
+const updateDeliveryOrderStatus = async (id: number, status: 'Approved' | 'Rejected'): Promise<DeliveryOrderResponse> => {
+    try {
+        const response = await axiosInstance.put(`/deliveryOrder/${id}/approve/${status}`);
+        return { success: true, data: response.data };
+    } catch (error: any) {
+        showError(error, `Failed to ${status.toLowerCase()} delivery order.`);
+        return {
+            success: false,
+            data: [],
+            message: error.response?.data?.message || error.response?.data?.error || `Failed to ${status.toLowerCase()} delivery order`
+        };
+    }
+};
+
 export const deliveryOrderService = {
     getDeliveryOrders,
     createDeliveryOrder,
     getSingleDeliveryOrder,
     getAttachmentsByDeliveryId,
     getAttachments2ByDeliveryId,
-    previewAttachment
+    previewAttachment,
+    updateDeliveryOrderStatus
 };

--- a/src/stores/delivery/delivery.store.ts
+++ b/src/stores/delivery/delivery.store.ts
@@ -179,6 +179,31 @@ export const useDeliveryStore = defineStore('deliveryStore', () => {
         fetchDeliveryOrders();
     }
 
+    async function updateDeliveryOrderStatus(id: number, status: 'Approved' | 'Rejected') {
+        loading.value = true;
+        try {
+            const response = await deliveryOrderService.updateDeliveryOrderStatus(id, status);
+
+            if (!response.success) {
+                showError(response.message || `Failed to update delivery order to ${status}.`);
+                return false;
+            }
+
+            showSuccess(response.message || `Delivery order successfully ${status.toLowerCase()}.`);
+            await fetchDeliveryOrders();
+            return true;
+        } catch (error: unknown) {
+            if (error instanceof Error) {
+                showError(error.message, 'Failed to update status.');
+            } else {
+                showError('An unexpected error occurred.', 'Failed to update status.');
+            }
+            return false;
+        } finally {
+            loading.value = false;
+        }
+    }
+
     // ------------------------------
     // RETURN
     // ------------------------------
@@ -201,6 +226,7 @@ export const useDeliveryStore = defineStore('deliveryStore', () => {
         setPage,
         setPageSize,
         setSorting,
-        setStatus
+        setStatus,
+        updateDeliveryOrderStatus
     };
 });

--- a/src/types/delivery.type.ts
+++ b/src/types/delivery.type.ts
@@ -111,6 +111,7 @@ export interface Step3DeliveryInfo {
     PlateNo: string;
     Date: string;
     DeliveryDate: string;
+    doNumber?: string;
     Remarks?: string;
     attachments?: File[];
     attachments2?: File[];
@@ -125,6 +126,7 @@ export interface DeliveryFlow {
 export interface FormValues {
     driverPlate: string;
     deliveryDate: Date | null;
+    doNumber?: string;
     remarks?: string;
 }
 

--- a/src/views/delivery/Deliveries.vue
+++ b/src/views/delivery/Deliveries.vue
@@ -72,6 +72,12 @@
                                 <ProButton variant="secondary" size="sm" @click="handleAction('view', row)" title="View Delivery">
                                     <PhEye :size="18" class="text-base text-gray-700" />
                                 </ProButton>
+                                <ProButton v-if="isPurchasingRole && row.Status === 'Created'" variant="success" size="sm" class="ml-2" @click="handleAction('approve', row)" title="Approve Delivery">
+                                    <PhCheckCircle :size="18" />
+                                </ProButton>
+                                <ProButton v-if="isPurchasingRole && row.Status === 'Created'" variant="danger" size="sm" class="ml-2" @click="handleAction('reject', row)" title="Reject Delivery">
+                                    <PhXCircle :size="18" />
+                                </ProButton>
                             </template>
                         </ProTable>
                     </Motion>
@@ -79,4 +85,46 @@
             </ProCard>
         </div>
     </Motion>
+
+    <!-- Approve Modal -->
+    <ProModal :modelValue="showApproveModal" @update:modelValue="(val: boolean) => { showApproveModal = val }" title="Confirm Approval" size="sm" class="!z-[1000]">
+        <div class="flex flex-col gap-4">
+            <p class="text-body-sm text-text-body">
+                Are you sure you want to approve delivery order <span v-if="selectedDeliveryNo" class="text-body-sm-bold text-text-heading">{{ selectedDeliveryNo }}</span>?
+            </p>
+        </div>
+        <template #footer>
+            <div class="flex justify-end gap-3">
+                <ProButton variant="secondary" @click="showApproveModal = false">
+                    <template #iconLeft><PhX :size="16" /></template>
+                    Cancel
+                </ProButton>
+                <ProButton variant="primary" @click="confirmApprove">
+                    <template #iconLeft><PhCheck :size="16" /></template>
+                    Yes, Approve
+                </ProButton>
+            </div>
+        </template>
+    </ProModal>
+
+    <!-- Reject Modal -->
+    <ProModal :modelValue="showRejectModal" @update:modelValue="(val: boolean) => { showRejectModal = val }" title="Confirm Rejection" size="sm" class="!z-[1000]">
+        <div class="flex flex-col gap-4">
+            <p class="text-body-sm text-text-body">
+                Are you sure you want to reject delivery order <span v-if="selectedDeliveryNo" class="text-body-sm-bold text-text-heading">{{ selectedDeliveryNo }}</span>?
+            </p>
+        </div>
+        <template #footer>
+            <div class="flex justify-end gap-3">
+                <ProButton variant="secondary" @click="showRejectModal = false">
+                    <template #iconLeft><PhX :size="16" /></template>
+                    Cancel
+                </ProButton>
+                <ProButton variant="danger" @click="confirmReject">
+                    <template #iconLeft><PhCheck :size="16" /></template>
+                    Yes, Reject
+                </ProButton>
+            </div>
+        </template>
+    </ProModal>
 </template>

--- a/src/views/delivery/Delivery.script.ts
+++ b/src/views/delivery/Delivery.script.ts
@@ -5,12 +5,12 @@ import { useConfirm } from 'primevue/useconfirm';
 import { useToast } from '@/utils/toastBus';
 import { computed, defineComponent, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
-import { ProCard, ProButton, ProTag, ProTable, ProTabs, ProSelect, ProDatePicker, ProInput } from '@prosync_solutions/ui';
-import { PhArrowsLeftRight, PhEye, PhPlus } from '@phosphor-icons/vue';
+import { ProCard, ProButton, ProTag, ProTable, ProTabs, ProSelect, ProDatePicker, ProInput, ProModal } from '@prosync_solutions/ui';
+import { PhArrowsLeftRight, PhEye, PhPlus, PhCheckCircle, PhXCircle, PhCheck, PhX } from '@phosphor-icons/vue';
 
 export default defineComponent({
     name: 'Deliveries',
-    components: { ProCard, ProButton, ProTag, ProTable, ProTabs, ProSelect, ProDatePicker, ProInput, PhArrowsLeftRight, PhEye, PhPlus },
+    components: { ProCard, ProButton, ProTag, ProTable, ProTabs, ProSelect, ProDatePicker, ProInput, ProModal, PhArrowsLeftRight, PhEye, PhPlus, PhCheckCircle, PhXCircle, PhCheck, PhX },
     setup() {
         const deliveryStore = useDeliveryStore();
         const projectStore = useProjectStore();
@@ -154,11 +154,38 @@ export default defineComponent({
             loadData();
         }
 
-        function handleAction(type: 'view', row: any) {
+        function handleAction(type: 'view' | 'approve' | 'reject', row: any) {
             if (type === 'view') {
                 router.push(`/deliveries/viewDelivery/${row.Id}`);
+            } else if (type === 'approve') {
+                selectedDeliveryId.value = row.Id;
+                selectedDeliveryNo.value = row.DocNo;
+                showApproveModal.value = true;
+            } else if (type === 'reject') {
+                selectedDeliveryId.value = row.Id;
+                selectedDeliveryNo.value = row.DocNo;
+                showRejectModal.value = true;
             }
         }
+
+        const showApproveModal = ref(false);
+        const showRejectModal = ref(false);
+        const selectedDeliveryId = ref<number | null>(null);
+        const selectedDeliveryNo = ref<string>('');
+
+        const confirmApprove = async () => {
+            if (selectedDeliveryId.value) {
+                await deliveryStore.updateDeliveryOrderStatus(selectedDeliveryId.value, 'Approved');
+                showApproveModal.value = false;
+            }
+        };
+
+        const confirmReject = async () => {
+            if (selectedDeliveryId.value) {
+                await deliveryStore.updateDeliveryOrderStatus(selectedDeliveryId.value, 'Rejected');
+                showRejectModal.value = false;
+            }
+        };
 
         onMounted(() => {
             deliveryStore.setStatus('Created'); // default = Pending
@@ -212,7 +239,14 @@ export default defineComponent({
             tableFilters,
             handleUpdatePagination,
             projectStore,
-            isPurchasingRole
+            isPurchasingRole,
+
+            showApproveModal,
+            showRejectModal,
+            selectedDeliveryId,
+            selectedDeliveryNo,
+            confirmApprove,
+            confirmReject
         };
     }
 });

--- a/src/views/delivery/components/deliveryWorkFlow/step1SelectPO/selectPO.script.ts
+++ b/src/views/delivery/components/deliveryWorkFlow/step1SelectPO/selectPO.script.ts
@@ -22,19 +22,26 @@ export default defineComponent({
         const showScanModal = ref(false);
         const selectedCard = ref<PurchaseOrderCard | null>(null);
         const manualSearch = ref('');
+        const supplierSearch = ref('');
 
         const filteredCards = computed(() => {
-            let data = purchaseStore.purchaseOrders.map((po) => ({
+            let data = purchaseStore.purchaseOrders.map((po: any) => ({
                 id: po.Id?.toString() ?? '',
                 title: po.DocNo ?? '',
-                content: `${po.PurchaseOrderItems?.length ?? 0} items`,
-                badges: po.PurchaseOrderItems?.map((i: PurchaseOrderItem) => i.ItemCode ?? '').filter(Boolean) ?? [],
-                icon: 'pi-box'
+                content: `${(po.purchase_order_items || po.PurchaseOrderItems)?.length ?? 0} items`,
+                badges: (po.purchase_order_items || po.PurchaseOrderItems)?.map((i: any) => i.ItemCode ?? i.code ?? i.itemCode ?? '').filter(Boolean) ?? [],
+                icon: 'pi-box',
+                supplierName: po.supplier?.CompanyName || ''
             }));
 
             if (manualSearch.value.trim()) {
                 const keyword = manualSearch.value.toLowerCase();
-                data = data.filter((card) => card.title.toLowerCase().includes(keyword) || card.badges.some((b) => b.toLowerCase().includes(keyword)));
+                data = data.filter((card) => card.title.toLowerCase().includes(keyword) || card.badges.some((b: string) => b.toLowerCase().includes(keyword)));
+            }
+
+            if (supplierSearch.value.trim()) {
+                const supplierKeyword = supplierSearch.value.toLowerCase();
+                data = data.filter((card) => card.supplierName.toLowerCase().includes(supplierKeyword));
             }
 
             return data;
@@ -57,11 +64,20 @@ export default defineComponent({
             manualSearch.value = query;
         };
 
-        // clear handler
+        // clear handlers
         const handleClearSearch = async () => {
             manualSearch.value = '';
             selectedCard.value = null;
-            purchaseStore.handleSearch(''); // Clear store search
+            const fullQuery = [manualSearch.value, supplierSearch.value].filter(Boolean).join(' ');
+            purchaseStore.handleSearch(fullQuery); 
+            await purchaseStore.fetchPurchaseOrders();
+        };
+
+        const handleClearSupplierSearch = async () => {
+            supplierSearch.value = '';
+            selectedCard.value = null;
+            const fullQuery = [manualSearch.value, supplierSearch.value].filter(Boolean).join(' ');
+            purchaseStore.handleSearch(fullQuery); 
             await purchaseStore.fetchPurchaseOrders();
         };
 
@@ -144,6 +160,14 @@ export default defineComponent({
         };
 
         let searchTimeout: any;
+        const triggerBackendSearch = (query: string) => {
+            clearTimeout(searchTimeout);
+            searchTimeout = setTimeout(async () => {
+                purchaseStore.handleSearch(query);
+                await purchaseStore.fetchPurchaseOrders();
+            }, 300);
+        };
+
         const handleManualSearchInput = (value: string | Event) => {
             let query = '';
             if (typeof value === 'object' && value && 'target' in value) {
@@ -153,13 +177,23 @@ export default defineComponent({
             } else {
                 query = manualSearch.value;
             }
+            manualSearch.value = query;
+            const fullQuery = [manualSearch.value, supplierSearch.value].filter(Boolean).join(' ');
+            triggerBackendSearch(fullQuery);
+        };
 
-            clearTimeout(searchTimeout);
-            searchTimeout = setTimeout(async () => {
-                purchaseStore.handleSearch(query);
-                await purchaseStore.fetchPurchaseOrders();
-                manualSearch.value = query;
-            }, 300);
+        const handleSupplierSearchInput = (value: string | Event) => {
+            let query = '';
+            if (typeof value === 'object' && value && 'target' in value) {
+                query = ((value as Event).target as HTMLInputElement).value;
+            } else if (typeof value === 'string') {
+                query = value;
+            } else {
+                query = supplierSearch.value;
+            }
+            supplierSearch.value = query;
+            const fullQuery = [manualSearch.value, supplierSearch.value].filter(Boolean).join(' ');
+            triggerBackendSearch(fullQuery);
         };
 
         //  Smart Scan handlers 
@@ -190,6 +224,7 @@ export default defineComponent({
             selectedCard,
             filteredCards,
             searchTerm: manualSearch,
+            supplierSearchTerm: supplierSearch,
             handlePOSearch,
             toggleSelect,
             removeCard,
@@ -202,11 +237,14 @@ export default defineComponent({
             displayEnd,
             purchaseStore,
             manualSearch,
+            supplierSearch,
             handlePageSizeChange,
             handleClearSearch,
+            handleClearSupplierSearch,
             onScanConfirm,
             onScanManual,
-            handleManualSearchInput
+            handleManualSearchInput,
+            handleSupplierSearchInput
         };
     }
 });

--- a/src/views/delivery/components/deliveryWorkFlow/step1SelectPO/selectPO.vue
+++ b/src/views/delivery/components/deliveryWorkFlow/step1SelectPO/selectPO.vue
@@ -27,10 +27,14 @@
                 <Form @submit="onFormSubmit" class="flex flex-col gap-4 mt-1 w-full sm:w-full">
                     <!-- AutoComplete Search -->
                     <!-- Search Section -->
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 p-3">
-                        <div class="flex gap-2 relative">
-                            <ProInput v-model="searchTerm" placeholder="Search PO Number..." class="w-full" @input="handleManualSearchInput" />
+                    <div class="flex flex-col md:flex-row gap-4 p-3 w-full">
+                        <div class="flex gap-2 relative flex-1 w-full">
+                            <ProInput v-model="searchTerm" placeholder="Search PO Number..." class="w-full flex-1" fluid @input="handleManualSearchInput" />
                             <ProButton variant="secondary" class="bg-gray-200 shrink-0" rounded @click="handleClearSearch" title="Clear search"><i class="pi pi-times mt-1 shrink-0" /></ProButton>
+                        </div>
+                        <div class="flex gap-2 relative flex-1 w-full">
+                            <ProInput v-model="supplierSearchTerm" placeholder="Search Supplier Name..." class="w-full flex-1" fluid @input="handleSupplierSearchInput" />
+                            <ProButton variant="secondary" class="bg-gray-200 shrink-0" rounded @click="handleClearSupplierSearch" title="Clear search"><i class="pi pi-times mt-1 shrink-0" /></ProButton>
                         </div>
                     </div>
 
@@ -48,6 +52,7 @@
                                 <div :class="['flex justify-between items-start', isSelected(card) ? 'mt-5' : 'mt-0']">
                                     <div>
                                         <h4 class="font-semibold mb-1">{{ card.title }}</h4>
+                                        <p class="text-sm font-medium text-gray-700 mb-1" v-if="card.supplierName">{{ card.supplierName }}</p>
                                         <p class="text-gray-600 mb-2 text-xs">{{ card.content }}</p>
                                         <div class="flex gap-2 flex-wrap" v-if="!isSelected(card)">
                                             <ProTag v-for="(badge, i) in card.badges" :key="i" :label="badge" variant="info" class="bg-gray-200 text-gray-700" />

--- a/src/views/delivery/components/deliveryWorkFlow/step2VerifyItem/verifyItem.vue
+++ b/src/views/delivery/components/deliveryWorkFlow/step2VerifyItem/verifyItem.vue
@@ -67,10 +67,7 @@
                                                 <div class="text-xs text-gray-500 font-medium">Ordered Qty</div>
                                                 <div class="font-semibold">{{ item.total }} <span class="text-gray-400 text-xs">{{ item.uom }}</span></div>
                                             </div>
-                                            <div>
-                                                <div class="text-xs text-gray-500 font-medium">Unit Price</div>
-                                                <div class="font-semibold">RM {{ item.price.toFixed(2) }}</div>
-                                            </div>
+
                                             <div>
                                                 <div class="text-xs text-gray-500 font-medium">RO Reference</div>
                                                 <div class="font-semibold text-xs">{{ item.roDocNo }}</div>

--- a/src/views/delivery/components/deliveryWorkFlow/step3DeliveryInfo/deliveryInfo.script.ts
+++ b/src/views/delivery/components/deliveryWorkFlow/step3DeliveryInfo/deliveryInfo.script.ts
@@ -1,16 +1,16 @@
 import { PhWarningCircle, PhTruck, PhFile, PhCamera } from '@phosphor-icons/vue';
 import { formatDateToAPI } from '@/utils/dateHelper';
-import Calendar from 'primevue/calendar';
 import Message from 'primevue/message';
 import Toast from 'primevue/toast';
 import { useToast } from '@/utils/toastBus';
+import type { FormValues } from '@/types/delivery.type';
 import { defineComponent, reactive, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
-import { ProCard, ProButton, ProTag, ProInput, ProTextarea, ProUploadFile } from '@prosync_solutions/ui';
+import { ProCard, ProButton, ProTag, ProInput, ProTextarea, ProUploadFile, ProDatePicker } from '@prosync_solutions/ui';
 
 export default defineComponent({
     name: 'DeliveryFormCard',
-    components: { Message, Toast, Calendar, ProCard, ProButton, ProTag, ProInput, ProTextarea, ProUploadFile, PhWarningCircle, PhTruck, PhFile, PhCamera },
+    components: { Message, Toast, ProDatePicker, ProCard, ProButton, ProTag, ProInput, ProTextarea, ProUploadFile, PhWarningCircle, PhTruck, PhFile, PhCamera },
     props: {
         prefillAttachment: {
             type: File,
@@ -29,7 +29,8 @@ export default defineComponent({
 
         const initialValues = reactive<FormValues>({
             driverPlate: '',
-            deliveryDate: null,
+            deliveryDate: new Date(),
+            doNumber: '',
             remarks: ''
         });
 
@@ -119,6 +120,7 @@ export default defineComponent({
                 PlateNo: values.driverPlate,
                 Date: formatDateToAPI(values.deliveryDate) || '',
                 DeliveryDate: formatDateToAPI(values.deliveryDate) || '',
+                doNumber: values.doNumber || '',
                 Remarks: values.remarks || '',
                 attachments: deliveryAttachments.value.map((f: any) => f.file || f.raw || f), // Delivery documents
                 attachments2: evidenceFiles.value.map((f: any) => f.file || f.raw || f) // Evidence/photos sent as attachments2
@@ -146,7 +148,8 @@ export default defineComponent({
 
             toastRef,
             onFormSubmit,
-            goBack
+            goBack,
+            formatDateToAPI
         };
     }
 });

--- a/src/views/delivery/components/deliveryWorkFlow/step3DeliveryInfo/deliveryInfo.vue
+++ b/src/views/delivery/components/deliveryWorkFlow/step3DeliveryInfo/deliveryInfo.vue
@@ -14,6 +14,8 @@
             </div>
             <form @submit.prevent="onFormSubmit" class="flex flex-col gap-4 mt-1 w-full">
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 p-3">
+                       
+                        
                         <div class="flex flex-col">
                             <label for="driverPlate">Driver Plate Number</label>
                             <ProInput name="driverPlate" v-model="initialValues.driverPlate" placeholder="Plate Number" fluid />
@@ -24,10 +26,14 @@
 
                         <div class="flex flex-col">
                             <label for="deliveryDate">Delivery Date</label>
-                            <Calendar name="deliveryDate" v-model="initialValues.deliveryDate" placeholder="Select Date" showIcon :showTime="false" dateFormat="yy-mm-dd" class="w-full" />
+                            <ProDatePicker name="deliveryDate" :modelValue="formatDateToAPI(initialValues.deliveryDate)" @update:modelValue="initialValues.deliveryDate = ($event ? new Date($event) : null)" placeholder="Select Date" class="w-full" disabled readonly />
                             <Message v-if="errors.deliveryDate" severity="error" size="small" variant="simple">
                                 {{ errors.deliveryDate }}
                             </Message>
+                        </div>
+                         <div class="flex flex-col md:col-span-2">
+                            <label for="doNumber">Delivery Order Number (Optional)</label>
+                            <ProInput name="doNumber" v-model="initialValues.doNumber" placeholder="Enter DO Number" fluid />
                         </div>
                     </div>
 

--- a/src/views/delivery/components/deliveryWorkFlow/step4Review/review.script.ts
+++ b/src/views/delivery/components/deliveryWorkFlow/step4Review/review.script.ts
@@ -84,7 +84,8 @@ export default defineComponent({
 
             const payload = {
                 PurchaseOrderId: selectPO.value.id ?? selectPO.value.purchaseOrderId,
-                DocNo: selectPO.value.poNumber ?? selectPO.value.DocNo,
+                DocNo: deliveryInfo.value.doNumber || selectPO.value.poNumber || selectPO.value.DocNo,
+                RefDoc: selectPO.value.poNumber || selectPO.value.DocNo,
                 Date: deliveryInfo.value.DeliveryDate,
                 PlateNo: deliveryInfo.value.PlateNo,
                 Remarks: deliveryInfo.value.Remarks,

--- a/src/views/delivery/components/deliveryWorkFlow/step4Review/review.vue
+++ b/src/views/delivery/components/deliveryWorkFlow/step4Review/review.vue
@@ -22,6 +22,10 @@
                             <span class="font-medium">Delivery Date:</span>
                             <span>{{ formatDate(deliveryInfo?.DeliveryDate) }}</span>
                         </div>
+                        <div class="flex justify-between" v-if="deliveryInfo?.Remarks">
+                            <span class="font-medium">Remarks:</span>
+                            <span class="text-right text-gray-700 whitespace-pre-wrap max-w-[70%]">{{ deliveryInfo?.Remarks }}</span>
+                        </div>
                         <div class="flex justify-between">
                             <span class="font-medium">Attachments:</span>
                             <span>{{ deliveryInfo?.attachments?.length || 0 }} uploaded</span>


### PR DESCRIPTION
- When selecting PO, it is supposed to show PO items; FE needs to map back as BE already provided the PO items
- on the delivery info page, need to use the current date as the default, and make it read-only
- add searching for the supplier name field also at the select PO process
- add supplier name to the PO number container
- take out the unit price in the second process
- missing PO number at DO view details
- adding the DO number field during the verify process
- replace Calendar with ProDatePicker at the Delivery Info step
- Implement approve & reject DO 
- passing remarks at the preview during the creation of new DO steps